### PR TITLE
Approach 1.  Fixes constant reboot for UI7 but probably breaks UI5

### DIFF
--- a/mochad/L_Mochad1.lua
+++ b/mochad/L_Mochad1.lua
@@ -5,11 +5,11 @@ local HADEVICE_SID  = "urn:micasaverde-com:serviceId:HaDevice1"
 local DIMMING_SID   = "urn:upnp-org:serviceId:Dimming1"
 local ALARM_SID     = "urn:micasaverde-com:serviceId:AlarmPartition2"
 
-local BINARY_SCHEMA  = "urn:schemas-micasaverde-com:device:BinaryLight:1"
-local DIMMING_SCHEMA = "urn:schemas-micasaverde-com:device:DimmableLight:1"
+local BINARY_SCHEMA  = "urn:schemas-upnp-org:device:BinaryLight:1"
+local DIMMING_SCHEMA = "urn:schemas-upnp-org:device:DimmableLight:1"
 local MOTION_SCHEMA  = "urn:schemas-micasaverde-com:device:MotionSensor:1"
-local DOOR_SCHEMA  = "urn:schemas-micasaverde-com:device:DoorSensor:1"
-local ALARM_SCHEMA = "urn:schemas-micasaverde-com:device:AlarmPartition:2"
+local DOOR_SCHEMA    = "urn:schemas-micasaverde-com:device:DoorSensor:1"
+local ALARM_SCHEMA   = "urn:schemas-micasaverde-com:device:AlarmPartition:2"
 
 
 local ipAddress


### PR DESCRIPTION
Not sure if this is supposed to work on UI5.
When adding BinaryLight or DimmableLight modules (A1,A2,etc), Mochad causes Vera to repeatedly crash and reboot on UI7.
This is because in UI7 the 'schema' parameter in the call to  'luup.chdev.append' used in function 'add_children' must either be blank or correct. (MCV has an interesting approach to dealing with errors)
Credit Bandanafish in  Reply #1 in the thread at: http://forum.micasaverde.com/index.php/topic,32747.msg241189.html#msg241189
MCV, of course, decided to change these values for UI7.  This is why I think this code will probably break UI5, so maybe it's better to just change the value for 'schema' to "".
